### PR TITLE
add MISR Remote Sensing SRGAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -2382,6 +2382,8 @@ Note that nearly all the MISR publications resulted from the [PROBA-V Super Reso
 
   14.1.16. [satlas-super-resolution](https://github.com/allenai/satlas-super-resolution) -> Satlas Super Resolution: model is an adaptation of ESRGAN, with changes that allow the input to be a time series of Sentinel-2 images.
 
+  14.1.17 [MISR Remote Sensing SRGAN](https://github.com/simon-donike/Remote-Sensing-SRGAN) -> PyTorch SRGAN for RGB Remote Sensing imagery, performing both SISR and MISR. MISR implementation inspired by RecursiveNet (HighResNet). Includes pretrained Checkpoints.
+
 ### 14.2. Single image super-resolution (SISR)
 
   14.2.1. [Super Resolution for Satellite Imagery - srcnn repo](https://github.com/WarrenGreen/srcnn)


### PR DESCRIPTION
Hi Rob,

this repository contains a muti-image remote sensing super-resulotion GAN. It is based on the SRGAN by [Ledig et al.](https://arxiv.org/abs/1609.04802v5) and the MISR implementation is inspired by the RecursiveNet from the HighResNet paper by [Deudon et al.](https://arxiv.org/abs/2002.06460)

This repository:

-  can perform both SISR and MISR
-  is easily retrainable and finetuneable due to the PyTorch Lightning implementation with WandB support and extensive documentation
- contains pretrained checkpoints.

Thanks for having a look,
Simon